### PR TITLE
Update todopage.css

### DIFF
--- a/public/todopage.css
+++ b/public/todopage.css
@@ -73,7 +73,7 @@
   overflow-y: auto;
   background: linear-gradient(to bottom, #0f2027, #203a43, #2c5364);
   display: flex;
-  flex-wrap: wrap;
+/*   flex-wrap: wrap; */
   justify-content: space-evenly;
   align-items: center;
 }


### PR DESCRIPTION
deleted a style of `todo-space: `
flexbox tries to fit all blocks in a single line by default, adding the `flex-wrap:wrap;` property enables the flexbox container to push the blocks to next line if they can't fit inside a single line.

for now this seemed to work fine with horizontal scrolling.